### PR TITLE
refactor(devcontainer): expose gitconfig path via env var

### DIFF
--- a/.devcontainer/dev.docker-compose.yml
+++ b/.devcontainer/dev.docker-compose.yml
@@ -18,10 +18,11 @@ services:
                 BIN_DEPLOY_REQ: ${BIN_DEPLOY_REQ}
                 SSH_AUTH_SOCK: /ssh-agent
                 BUN_BIN: ${BUN_BIN_R}
+                GITCONFIG_PATH: ${GITCONFIG_PATH}
         volumes:
             - ${SSH_AUTH_SOCK:-/dev/null}:/ssh-agent
             - .:/workspace
-            - ~/.gitconfig:/etc/gitconfig:ro
+            - ${GITCONFIG_PATH:-${HOME}/.gitconfig}:/etc/gitconfig:ro
         networks:
             - templrjs
             - ollama


### PR DESCRIPTION
Add GITCONFIG_PATH env variable and use it in volume mapping with default to $HOME/.gitconfig. This allows custom gitconfig location for dev container.